### PR TITLE
change a few things for the PR

### DIFF
--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -31,7 +31,7 @@ build:rbe --disk_cache=
 build:rbe --incompatible_enable_cc_toolchain_resolution
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 test:rbe --test_env=DISPLAY=:99.0
-test:rbe --test_tag_filters=-exclusive-if-local,-skip-rbe,-remote
+test:rbe --test_tag_filters=-exclusive-if-local,-remote
 
 # Env vars we can hard code
 build:rbe --action_env=HOME=/home/dev

--- a/cpp/iedriver/Alert.cpp
+++ b/cpp/iedriver/Alert.cpp
@@ -26,6 +26,7 @@
 
 #define INVALID_CONTROL_ID -1
 
+// Changing this one for sure
 namespace webdriver {
 
 Alert::Alert(std::shared_ptr<DocumentHost> browser, HWND handle) {
@@ -81,7 +82,7 @@ int Alert::Accept() {
     LOG(INFO) << "OK button does not exist on dialog; looking for Cancel button";
     button_info = this->GetDialogButton(CANCEL);
   }
-    
+
   if (!button_info.button_exists) {
     LOG(WARN) << "OK and Cancel button do not exist on alert";
     return EUNHANDLEDERROR;
@@ -239,7 +240,7 @@ std::string Alert::GetStandardDialogText() {
                        &Alert::FindTextLabel,
                        reinterpret_cast<LPARAM>(&info));
   }
-  
+
   std::string alert_text_value;
   if (info.label_handle == NULL) {
     alert_text_value = "";

--- a/java/test/org/openqa/selenium/bidi/input/DefaultKeyboardTest.java
+++ b/java/test/org/openqa/selenium/bidi/input/DefaultKeyboardTest.java
@@ -72,6 +72,19 @@ class DefaultKeyboardTest extends JupiterTestBase {
   }
 
   @Test
+  void testSomethingElse() {
+    driver.get(appServer.whereIs("single_text_input.html"));
+
+    WebElement input = driver.findElement(By.id("textInput"));
+
+    Actions sendLowercase = getBuilder(driver).sendKeys(input, "12345");
+
+    inputModule.perform(windowHandle, sendLowercase.getSequences());
+
+    shortWait.until(ExpectedConditions.attributeToBe(input, "value", "12345"));
+  }
+
+  @Test
   @NotYetImplemented(SAFARI)
   public void testSendingKeyDownOnly() {
     driver.get(appServer.whereIs("key_logger.html"));


### PR DESCRIPTION
### **User description**
<!-- Thanks for Contributing to Selenium! -->
<!-- Please read our contribution guidelines: https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md -->

### 🔗 Related Issues
No issue, really

### 💥 What does this PR do?
Does some really important stuff with Rust, some great features really

### 🔧 Implementation Notes
It's the best way to do it, honestly. Really makes a difference to Microsoft Edge in particular

### 💡 Additional Considerations
Nope, that's all there is

### 🔄 Types of changes
<!-- ✂️ Please delete anything that doesn't apply -->
- Cleanup (formatting, renaming)
- Bug fix (backwards compatible)
- New feature (non-breaking change which adds functionality *and tests!*)
- Breaking change (fix or feature that would cause existing functionality to change)


___

### **PR Type**
Tests, Bug fix, Cleanup


___

### **Description**
- Added a new test for keyboard input validation in `DefaultKeyboardTest`.

- Modified `Alert.cpp` to improve formatting and added a comment.

- Updated `.bazelrc.remote` to adjust test tag filters for remote execution.

- Minor cleanup and formatting changes in `Alert.cpp`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DefaultKeyboardTest.java</strong><dd><code>Added new test for numeric keyboard input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java/test/org/openqa/selenium/bidi/input/DefaultKeyboardTest.java

<li>Added a new test method <code>testSomethingElse</code>.<br> <li> Validates numeric input handling for keyboard actions.


</details>


  </td>
  <td><a href="https://github.com/titusfortner/selenium/pull/102/files#diff-a4b533150d3d228d69ab0c5228e98b5479bd1b1bf3267fade1f5ac429a60e583">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Alert.cpp</strong><dd><code>Minor formatting and comment addition in Alert.cpp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cpp/iedriver/Alert.cpp

<li>Added a comment in the namespace section.<br> <li> Minor formatting adjustments for better readability.


</details>


  </td>
  <td><a href="https://github.com/titusfortner/selenium/pull/102/files#diff-fcc98626c4992a5fc1b9bb55dd25da15ee28667b4be55306a92f2f2bda5c7fc3">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.bazelrc.remote</strong><dd><code>Updated Bazel remote execution test filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.bazelrc.remote

<li>Updated test tag filters to exclude <code>-remote</code>.<br> <li> Adjusted configuration for remote execution.


</details>


  </td>
  <td><a href="https://github.com/titusfortner/selenium/pull/102/files#diff-81c4b7362f2e859c22b1d4cbe205f550889ee1aa9a0999552a385ab643ee1451">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>